### PR TITLE
Feat/encrypt personal info

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -816,6 +816,11 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "body-parser": "^1.18.3",
     "cors": "^2.8.4",
+    "crypto-js": "^3.1.9-1",
     "dotenv": "^6.0.0",
     "express": "^4.16.3",
     "express-rate-limit": "^2.11.0",

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "NODE_ENV=production node ./src/index.js",
-    "dev": "NODE_ENV=develop node ./src/index.js",
+    "dev": "NODE_ENV=develop node --inspect ./src/index.js",
     "test": "rimraf .nyc_output && NODE_ENV=test ./node_modules/.bin/nyc --reporter=text ./node_modules/mocha/bin/mocha test/**/*.spec.js --timeout 20000",
     "lint": "eslint src test",
     "coverage": "nyc report --reporter=text-lcov | coveralls"

--- a/server/src/models/Booking.js
+++ b/server/src/models/Booking.js
@@ -72,7 +72,7 @@ const Booking = new Schema({
     type: Boolean,
     default: false,
   },
-  lastChange: {
+  changesEmailSent: {
     type: Number,
     default: function () {
       return Date.now() / 1000;

--- a/server/src/models/Booking.js
+++ b/server/src/models/Booking.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { AES, enc } = require('crypto-js');
 const Schema = mongoose.Schema;
 const { SIGNATURE_TIME_LIMIT, ROOM_TYPE_PRICES, BOOKING_PAYMENT_TYPES,
   BOOKING_ROOM_TYPES, BOOKING_STATUS } = require('../constants');
@@ -87,19 +88,31 @@ const Booking = new Schema({
 });
 
 Booking.method({
-  encryptPersonalInfo: function (personalInfo) {
+  encryptPersonalInfo: function (personalInfo, bookingHash) {
     if (typeof personalInfo !== 'object') {
       throw handleApplicationError('invalidPersonalInfo');
     }
-    personalInfo = JSON.stringify(personalInfo);
-    this.encryptedPersonalInfo = web3.utils.stringToHex(personalInfo);
-  },
-  decryptPersonalInfo: function () {
-    if (!web3.utils.isHex(this.encryptedPersonalInfo)) {
-      throw handleApplicationError('invalidEncryptedPersonalInfo');
+    if (!bookingHash) {
+      throw handleApplicationError('noBookingHash');
     }
-    let decoded = web3.utils.hexToString(this.encryptedPersonalInfo);
-    return JSON.parse(decoded);
+    personalInfo = JSON.stringify(personalInfo);
+    const hexEncoded = web3.utils.stringToHex(personalInfo);
+    this.encryptedPersonalInfo = AES.encrypt(hexEncoded, bookingHash).toString();
+  },
+  decryptPersonalInfo: function (bookingHash) {
+    let bytes;
+    let encodedPersonalInfo;
+    try {
+      bytes = AES.decrypt(this.encryptedPersonalInfo, bookingHash);
+      encodedPersonalInfo = bytes.toString(enc.Utf8);
+    } catch (e) {
+      encodedPersonalInfo = null;
+    }
+    if (!web3.utils.isHex(encodedPersonalInfo)) {
+      return {};
+    }
+    const personalInfo = web3.utils.hexToString(encodedPersonalInfo);
+    return JSON.parse(personalInfo);
   },
   generateBookingHash: function () {
     const randomCode = Math.floor((1 + Math.random()) * 10000);
@@ -154,8 +167,8 @@ Booking.statics.generate = function (data) {
   const { personalInfo, ethPrice, ...rest } = data;
   const BookingModel = this.model('Booking');
   const booking = new BookingModel(rest);
-  booking.encryptPersonalInfo(personalInfo);
   booking.generateBookingHash();
+  booking.encryptPersonalInfo(personalInfo, booking.bookingHash);
   booking.generatePaymentAmount(ethPrice);
   return booking;
 };

--- a/server/test/controllers/Booking.spec.js
+++ b/server/test/controllers/Booking.spec.js
@@ -73,11 +73,7 @@ describe('Booking controller', () => {
     expect(booking).to.have.property('paymentType', validBookingWithEthPrice.paymentType);
     expect(booking).to.have.property('signatureTimestamp');
     expect(booking.signatureTimestamp).to.have.a('number');
-    expect(booking).to.have.property('personalInfo');
-    expect(booking.personalInfo).to.have.property('name', validBookingWithEthPrice.personalInfo.name);
-    expect(booking.personalInfo).to.have.property('email', validBookingWithEthPrice.personalInfo.email);
-    expect(booking.personalInfo).to.have.property('birthday', validBookingWithEthPrice.personalInfo.birthday);
-    expect(booking.personalInfo).to.have.property('phone', validBookingWithEthPrice.personalInfo.phone);
+    expect(booking.personalInfo).to.be.deep.equal({});
     expect(booking).to.have.property('roomType', validBookingWithEthPrice.roomType);
     expect(booking).to.have.property('to', validBookingWithEthPrice.to);
     expect(booking).to.have.property('from', validBookingWithEthPrice.from);

--- a/server/test/controllers/Booking.spec.js
+++ b/server/test/controllers/Booking.spec.js
@@ -37,7 +37,7 @@ describe('Booking controller', () => {
     expect(booking).to.have.property('roomType');
     expect(booking.roomType).to.be.a('string');
     expect(booking).to.have.property('confirmationEmailSent', false);
-    expect(booking).to.have.property('lastChange');
+    expect(booking).to.have.property('changesEmailSent');
     expect(offerSignature).to.not.be.an('undefined');
   });
 
@@ -82,7 +82,7 @@ describe('Booking controller', () => {
     expect(booking).to.have.property('to', validBookingWithEthPrice.to);
     expect(booking).to.have.property('from', validBookingWithEthPrice.from);
     expect(booking).to.have.property('confirmationEmailSent', false);
-    expect(booking).to.have.property('lastChange');
+    expect(booking).to.have.property('changesEmailSent');
   });
 
   it('Should read a booking using bookingHash', async () => {
@@ -116,13 +116,13 @@ describe('Booking controller', () => {
     await dbBooking.save();
     const booking = await confirmationEmailSentBooking(dbBooking._id);
     expect(booking).to.have.property('confirmationEmailSent', true);
-    expect(booking).to.have.property('lastChange');
+    expect(booking).to.have.property('changesEmailSent');
   });
   it('Should set changesEmailSent as true', async () => {
     const dbBooking = BookingModel.generate(validBookingWithEthPrice);
-    const { lastChange } = await dbBooking.save();
+    const { changesEmailSent } = await dbBooking.save();
     const booking = await changesEmailSentBooking(dbBooking._id);
     expect(booking).to.have.property('confirmationEmailSent', false);
-    expect(booking.lastChange).to.be.at.least(lastChange);
+    expect(booking.changesEmailSent).to.be.at.least(changesEmailSent);
   });
 });


### PR DESCRIPTION
Added `AES` encryption to personal information. When you call the controller function `createBooking` returns the `personalInfo` decrypted. 
When you call the function `readBooking` only returns the `personalInfo` decrypted when you use a valid filter `bookingHash`. Otherwise, `personalInfo` will be an empty object, @AugustoL let me know if you want to change it to a `null`

#### Updated `encryptPersonalInfo`: 
Now receives the `personalInfo` and the `bookingHash`
#### Updated `decryptPersonalInfo` 
Now receives the `bookingHash`

### Other changes
I added the prop `--inspect` for debugging and changed the attribute name `lastChange` to `changesEmailSent`.
@MatiasOS You where using `lastChange` in the Booking model but `changesEmailSent` in the controller function. Let me know if this fix is ok or should I revert [this commit](https://github.com/windingtree/crypto-booking-app/pull/78/commits/b5994a4430b7e2718cf568e6929b179ac4641bf9)

------

#### TODO
Use another secret phrase that is not `bookinghash`