### PR TITLE
feat(booking API): return bookingIndex in POST /booking

### DIFF
--- a/server/src/controllers/Booking.js
+++ b/server/src/controllers/Booking.js
@@ -13,7 +13,7 @@ const { FROM_EMAIL } = require('../config');
   */
 async function createBooking (data) {
   data.cryptoPrice = await fetchPrice(data.paymentType);
-  const { privateKey, publicKey, index } = generateKeyPair();
+  const { privateKey, publicKey, index: bookingIndex } = generateKeyPair();
   data.bookingHash = publicKey;
   const bookingModel = BookingModel.generate(data, privateKey);
   await bookingModel.save();
@@ -25,7 +25,7 @@ async function createBooking (data) {
     booking,
     offerSignature,
     signatureData,
-    index,
+    bookingIndex,
     privateKey,
   };
 }

--- a/server/src/routes/index.js
+++ b/server/src/routes/index.js
@@ -14,7 +14,7 @@ const bookingUrl = '/booking';
 
 router.post(`${bookingUrl}`, recaptchaMiddleware, async (req, res, next) => {
   try {
-    const { signatureData, booking, offerSignature } = await createBooking(req.body);
+    const { signatureData, booking, offerSignature, bookingIndex } = await createBooking(req.body);
     const nights = [];
     for (let i = booking.from; i <= booking.to; i++) {
       nights.push(i);
@@ -26,6 +26,7 @@ router.post(`${bookingUrl}`, recaptchaMiddleware, async (req, res, next) => {
       offerSignature,
       signatureData,
       contractAddress: BOOKING_POC_ADDRESS,
+      bookingIndex
     };
 
     sendInstructions(data, {
@@ -41,7 +42,7 @@ router.post(`${bookingUrl}`, recaptchaMiddleware, async (req, res, next) => {
 
 router.get(`${bookingUrl}/:bookingHash`, async (req, res, next) => {
   try {
-    const booking = await readBooking({ bookingHash: req.params.bookingHash }, parseInt(req.query.index));
+    const booking = await readBooking({ bookingHash: req.params.bookingHash }, parseInt(req.query.bookingIndex));
     if (!booking) return next();
     res.json(booking);
   } catch (e) {
@@ -56,7 +57,7 @@ router.post(`${bookingUrl}/emailInfo`, createThrottlingInstance({
   max: 3, // Start blocking after 3 requests
 }), async (req, res, next) => {
   try {
-    await sendBookingInfoByEmail(req.body.bookingHash, parseInt(req.body.index));
+    await sendBookingInfoByEmail(req.body.bookingHash, parseInt(req.body.bookingIndex));
     res.json({ status: 'ok' });
   } catch (e) {
     return next(e);

--- a/server/test/controllers/Booking.spec.js
+++ b/server/test/controllers/Booking.spec.js
@@ -37,7 +37,7 @@ describe('Booking controller', () => {
   });
 
   it('Should create a valid booking', async function () {
-    const { booking, offerSignature, index, privateKey } = await createBooking(validBooking);
+    const { booking, offerSignature, bookingIndex, privateKey } = await createBooking(validBooking);
     expect(booking).to.have.property('bookingHash');
     expect(booking.bookingHash).to.be.a('string');
     expect(booking).to.have.property('guestEthAddress', validBooking.guestEthAddress);
@@ -56,7 +56,7 @@ describe('Booking controller', () => {
     expect(booking).to.have.property('changesEmailSent');
     expect(booking).to.have.property('guestCount', validBooking.guestCount);
     expect(offerSignature).to.not.be.an('undefined');
-    expect(index).to.be.an('number');
+    expect(bookingIndex).to.be.an('number');
     expect(privateKey).to.be.an('string');
   });
 

--- a/server/test/routes/index.spec.js
+++ b/server/test/routes/index.spec.js
@@ -7,7 +7,7 @@ const sinon = require('sinon');
 const sgMail = require('@sendgrid/mail');
 const { SERVER_PORT } = require('../../src/config');
 const throttling = require('../../src/middlewares/throttling');
-const { setCryptoIndex, getCryptoIndex } = require('../../src/services/crypto');
+const { setCryptoIndex } = require('../../src/services/crypto');
 const {
   turnOffRecaptcha,
   turnOnRecaptcha,
@@ -74,7 +74,7 @@ describe('Booking API', () => {
     });
     it('Should create a valid ETH booking', async () => {
       const body = validBooking;
-      const { booking, txs } = await request({ url: `${apiUrl}/booking`, method: 'POST', json: true, body });
+      const { booking, txs, bookingIndex } = await request({ url: `${apiUrl}/booking`, method: 'POST', json: true, body });
       expect(txs.length).to.be.an.equal(1);
       expect(txs[0]).to.have.property('to');
       expect(txs[0]).to.have.property('data');
@@ -94,12 +94,13 @@ describe('Booking API', () => {
       expect(booking.personalInfo).to.have.property('birthDate', validBooking.personalInfo.birthDate);
       expect(booking.personalInfo).to.have.property('phone', validBooking.personalInfo.phone);
       expect(booking.personalInfo).to.have.property('phone', validBooking.personalInfo.phone);
+      expect(bookingIndex).to.be.a('number');
       const sendFake = sandbox.getFakes()[0];
       expect(sendFake).to.have.property('calledOnce', true);
     });
     it('Should create a valid LIF booking', async () => {
       const body = validLifBooking;
-      const { booking, txs } = await request({ url: `${apiUrl}/booking`, method: 'POST', json: true, body });
+      const { booking, txs, bookingIndex } = await request({ url: `${apiUrl}/booking`, method: 'POST', json: true, body });
       expect(txs.length).to.be.an.equal(2);
       expect(txs[1]).to.have.property('to');
       expect(txs[1]).to.have.property('data');
@@ -117,6 +118,7 @@ describe('Booking API', () => {
       expect(booking.personalInfo).to.have.property('email', validLifBooking.personalInfo.email);
       expect(booking.personalInfo).to.have.property('birthDate', validLifBooking.personalInfo.birthDate);
       expect(booking.personalInfo).to.have.property('phone', validLifBooking.personalInfo.phone);
+      expect(bookingIndex).to.be.a('number');
       const sendFake = sandbox.getFakes()[0];
       expect(sendFake).to.have.property('calledOnce', true);
     });
@@ -138,7 +140,7 @@ describe('Booking API', () => {
       const dbBooking = BookingModel.generate(validBookingWithEthPrice, validBookingWithEthPrice.privateKey);
       await dbBooking.save();
       const index = 0;
-      const booking = await request({ url: `${apiUrl}/booking/${dbBooking.bookingHash}?index=${index}`, method: 'GET', json: true });
+      const booking = await request({ url: `${apiUrl}/booking/${dbBooking.bookingHash}?bookingIndex=${index}`, method: 'GET', json: true });
       expect(booking).to.have.property('_id');
       expect(booking).to.have.property('bookingHash');
       expect(booking).to.have.property('guestEthAddress', validBooking.guestEthAddress);


### PR DESCRIPTION
I returned the `bookingIndex` when a booking is created.

Now the endpoint `POST /api/booking` returns a property `bookingIndex` that is used to decrypt the personal information