### PR TITLE
Feat/add validations to booking cancel

### DIFF
--- a/app/src/components/MyBookingSection/index.jsx
+++ b/app/src/components/MyBookingSection/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import $ from 'jquery'
 import EmailSentModal from './EmailSentModal'
 import DeleteInstructionsModal from './DeleteInstructionsModal'
@@ -50,16 +50,17 @@ export default class MyBookingSection extends React.Component {
       const {bookingHash, bookingIndex} = this.state
       const data = {bookingHash, bookingIndex}
       // TODO check this when server can handle this request
-      const response = await (await fetch(SIGNER_API + '/booking', {
+      const response = await (await fetch(SIGNER_API + '/api/booking', {
         method: 'DELETE',
         body: JSON.stringify(data),
         headers: {
           'Content-Type': 'application/json'
         }
       })).json()
-      if (response.status > 400) {
-        console.error(response.code)
-        alert(response.long || response.short)
+      if (response.status >= 400) {
+        console.error(response)
+        this.setState({errorMessage: response.long, loading: false}, this.showErrorAlert)
+        return
       }
       this.setState({cancelTx: {
         to: response.tx.to,
@@ -73,48 +74,63 @@ export default class MyBookingSection extends React.Component {
 
   }
 
+  showErrorAlert = () => {
+    $('.alert').addClass('show')
+    setTimeout(() => {
+      $('.alert').removeClass('show')
+    }, 3000)
+  }
+
   render () {
-    const {cancelTx} = this.state
+    const {cancelTx, errorMessage} = this.state
     return (
-      <article className="py-3 py-md-5 border-bottom" id="my-booking">
-        <div className="container">
-          <div className="row justify-content-center">
-            <div className="col-md-8 text-center">
-              <h2 className="mb-1"> My Booking </h2>
-              <p className="mb-2"> Please enter the data below. </p>
-              <form onSubmit={this.onSubmit}>
-                <div className="form-group text-left">
-                  <label htmlFor="userBookingHash"> <b>Booking hash</b> </label>
-                  <input className="form-control form-control-lg mb-2"
-                         id="userBookingHash"
-                         placeholder="Booking hash"
-                         autoComplete="off"
-                         onChange={this.onHashChange}
-                         type="text"
-                         required/>
-                </div>
-                <div className="form-group text-left">
-                  <label htmlFor="userBookingIndex"> <b>Booking index</b> </label>
-                  <input className="form-control form-control-lg mb-2"
-                         id="userBookingIndex"
-                         placeholder="Booking Index"
-                         autoComplete="off"
-                         onChange={this.onIndexChange}
-                         type="text"
-                         required/>
-                </div>
-                <div className="form-group">
-                  <button className="btn btn-primary btn-lg" type="submit"> Retrieve booking data</button>
-                  <br/>
-                  <button className="btn btn-link btn-sm text-danger"style={{marginTop: '.5em'}} type="button" onClick={this.onCancel}> Cancel my Booking</button>
-                </div>
-              </form>
+      <Fragment>
+        <div className="alert fade fixed-top alert-danger text-center" role="alert">
+          <span>{errorMessage}</span>
+          <button type="button" className="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <article className="py-3 py-md-5 border-bottom" id="my-booking">
+          <div className="container">
+            <div className="row justify-content-center">
+              <div className="col-md-8 text-center">
+                <h2 className="mb-1"> My Booking </h2>
+                <p className="mb-2"> Please enter the data below. </p>
+                <form onSubmit={this.onSubmit}>
+                  <div className="form-group text-left">
+                    <label htmlFor="userBookingHash"> <b>Booking hash</b> </label>
+                    <input className="form-control form-control-lg mb-2"
+                           id="userBookingHash"
+                           placeholder="Booking hash"
+                           autoComplete="off"
+                           onChange={this.onHashChange}
+                           type="text"
+                           required/>
+                  </div>
+                  <div className="form-group text-left">
+                    <label htmlFor="userBookingIndex"> <b>Booking index</b> </label>
+                    <input className="form-control form-control-lg mb-2"
+                           id="userBookingIndex"
+                           placeholder="Booking Index"
+                           autoComplete="off"
+                           onChange={this.onIndexChange}
+                           type="text"
+                           required/>
+                  </div>
+                  <div className="form-group">
+                    <button className="btn btn-primary btn-lg" type="submit"> Retrieve booking data</button>
+                    <br/>
+                    <button className="btn btn-link btn-sm text-danger"style={{marginTop: '.5em'}} type="button" onClick={this.onCancel}> Cancel my Booking</button>
+                  </div>
+                </form>
+              </div>
             </div>
           </div>
-        </div>
-        <EmailSentModal/>
-        {cancelTx && <DeleteInstructionsModal {...cancelTx}/>}
-      </article>
+          <EmailSentModal/>
+          {cancelTx && <DeleteInstructionsModal {...cancelTx}/>}
+        </article>
+      </Fragment>
     )
   }
 }

--- a/server/src/controllers/Booking.js
+++ b/server/src/controllers/Booking.js
@@ -78,8 +78,11 @@ async function readBooking (filter, index) {
 }
 
 async function getCancelBookingInstructions (bookingHash) {
+  if (!bookingHash) {
+    throw handleApplicationError('noBookingHashFromClient');
+  }
   const bookingModel = await BookingModel.findOne({ bookingHash }).exec();
-  if (!bookingModel) {
+  if (!bookingModel || bookingModel.status !== BOOKING_STATUS.approved) {
     throw handleApplicationError('bookingNotFound');
   }
   const { roomType, roomNumber, from, to, paymentType } = bookingModel;

--- a/server/src/errors/codes.js
+++ b/server/src/errors/codes.js
@@ -31,6 +31,11 @@ module.exports = {
     short: 'Invalid eth price.',
     long: 'The cryptoPrice must be a number.',
   },
+  noBookingHashFromClient: {
+    status: 409,
+    short: 'No booking hash provided',
+    long: 'A booking hash must be sent to find the booking',
+  },
   whiteList: {
     status: 403,
     short: 'IP is not whitelisted.',

--- a/server/test/controllers/Booking.spec.js
+++ b/server/test/controllers/Booking.spec.js
@@ -208,6 +208,7 @@ describe('Booking controller', () => {
   it('Should generate tx for cancel booking', async () => {
     const dbBooking = BookingModel.generate(validBookingWithEthPrice, validBookingWithEthPrice.privateKey);
     await dbBooking.save();
+    await dbBooking.setAsApproved();
     const tx = await getCancelBookingInstructions(dbBooking.bookingHash);
     expect(tx).to.have.property('to', BOOKING_POC_ADDRESS);
     expect(tx).to.have.property('data');

--- a/server/test/routes/index.spec.js
+++ b/server/test/routes/index.spec.js
@@ -224,6 +224,7 @@ describe('Booking API', () => {
     it('Should delete a booking', async () => {
       const dbBooking = BookingModel.generate(validBookingWithEthPrice, validBookingWithEthPrice.privateKey);
       await dbBooking.save();
+      await dbBooking.setAsApproved();
       const body = { bookingHash: validBookingWithEthPrice.bookingHash };
       const { tx } = await request({ url: `${apiUrl}/booking`, method: 'DELETE', json: true, body });
       expect(tx).to.have.property('to', BOOKING_POC_ADDRESS);
@@ -234,6 +235,18 @@ describe('Booking API', () => {
     it('Should retrun 404 for invalid bookingHash', async () => {
       try {
         const body = { bookingHash: 'invalidHash' };
+        await request({ url: `${apiUrl}/booking`, method: 'DELETE', json: true, body });
+        throw new Error('should not be called');
+      } catch (e) {
+        expect(e).to.have.property('error');
+        expect(e.error).to.have.property('code', '#bookingNotFound');
+      }
+    });
+    it('Should retrun 404 for non approved booking', async () => {
+      try {
+        const dbBooking = BookingModel.generate(validBookingWithEthPrice, validBookingWithEthPrice.privateKey);
+        await dbBooking.save();
+        const body = { bookingHash: validBookingWithEthPrice.bookingHash };
         await request({ url: `${apiUrl}/booking`, method: 'DELETE', json: true, body });
         throw new Error('should not be called');
       } catch (e) {


### PR DESCRIPTION
-  Added an error alert in FE
![screen shot 2018-08-06 at 10 55 44 pm](https://user-images.githubusercontent.com/1965274/43749965-9619b2ac-99cc-11e8-94aa-b30af8a8f395.png)

- Added validations to the endpoint `DELETE /api/booking` now returns an error if the booking hash is missing
```
{
    status: 409,
    short: 'No booking hash provided',
    long: 'A booking hash must be sent to find the booking',
 }
```
also, if the booking is not approved the endpoint will return "booking not found" because we should only cancel approved bookings. @AugustoL do you want me to return a different error?

This resolves #251