### PR TITLE
chore(app): Remove cloudFlare cache clean

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,6 @@
     "deploy-now": "NODE_ENV=production now --team windingtree --token $NOW_TOKEN",
     "now-start": "serve --single ./public",
     "alias": "now alias --team windingtree --token=$NOW_TOKEN",
-    "postalias": "./scripts/cloudflare-cachepurge.sh",
     "postinstall": "npm install https://github.com/windingtree/wt-ui.git#develop"
   },
   "devDependencies": {


### PR DESCRIPTION
Remove temporally script until we have credentials. This is making release-app stage fail on travis.