### PR TITLE
fix(Date selector): start with first two days selected

### DIFF
--- a/app/src/components/Booking/FormSection/index.jsx
+++ b/app/src/components/Booking/FormSection/index.jsx
@@ -46,6 +46,7 @@ class FormSection extends React.Component {
 
   componentDidMount () {
     this.bookingPoC = new this.web3.eth.Contract(BookingPoC.abi, BOOKING_POC_ADDRESS)
+    this.computePrice()
   }
 
   _mapDateToInteger = (date) => {


### PR DESCRIPTION
As @skkr requested in #294 I changed the default dates to the first two days.

------

#### Edited
After talking with @AugustoL we decide to left the default days from 1 to 5. In this PR I added the function to calculate the price on component did mount