### PR TITLE
fix(black-screen): remove modal black screen on error

### DIFF
--- a/app/src/components/Booking/FormSection/RoomBooking.jsx
+++ b/app/src/components/Booking/FormSection/RoomBooking.jsx
@@ -57,8 +57,6 @@ export default class RoomBooking extends React.Component {
 
   render() {
     const {
-      toDateMin,
-      fromDateMax,
       phone,
       to,
       email,
@@ -171,8 +169,6 @@ export default class RoomBooking extends React.Component {
 }
 
 RoomBooking.propTypes = {
-  toDateMin: PropTypes.string.isRequired,
-  fromDateMax: PropTypes.string.isRequired,
   email: PropTypes.string.isRequired,
   phone: PropTypes.string.isRequired,
   from: PropTypes.number.isRequired,

--- a/app/src/components/Booking/FormSection/index.jsx
+++ b/app/src/components/Booking/FormSection/index.jsx
@@ -39,7 +39,7 @@ class FormSection extends React.Component {
       fromDateMax: '2018-09-09',
       price: null,
       guestCount: '1',
-      errorMessage: 'asdasdasdasdasd'
+      errorMessage: ''
     }
   }
 

--- a/app/src/components/Booking/FormSection/index.jsx
+++ b/app/src/components/Booking/FormSection/index.jsx
@@ -124,6 +124,7 @@ class FormSection extends React.Component {
     $('.alert').addClass('show')
     setTimeout(() => {
       $('.alert').removeClass('show')
+      this.setState({errorMessage: ''})
     }, 3000)
   }
 
@@ -192,12 +193,12 @@ class FormSection extends React.Component {
     if (instructions || loading) return <CheckEmail onClose={this.onCloseModal} instructions={instructions} loading={loading}/>
     return (
       <Fragment>
-          <div className="alert fade fixed-top alert-danger text-center" role="alert">
+          { errorMessage && (<div className="alert fade fixed-top alert-danger text-center" role="alert">
             <span>{errorMessage}</span>
             <button type="button" className="close" data-dismiss="alert" aria-label="Close">
               <span aria-hidden="true">&times;</span>
             </button>
-          </div>
+          </div>)}
         <RoomBooking
           from={from}
           to={to}

--- a/app/src/components/Booking/FormSection/index.jsx
+++ b/app/src/components/Booking/FormSection/index.jsx
@@ -160,8 +160,14 @@ class FormSection extends React.Component {
           'Content-Type': 'application/json'
         }
       })).json()
+
       if (response.status >= 400) {
         console.error(response)
+        // HOT FIX to remove blackscreen on error. We should remove bootstrap or use https://react-bootstrap.github.io/
+        const modal = document.querySelector('.modal-backdrop')
+        if(modal){
+          modal.remove()
+        }
         this.setState({errorMessage: response.long, loading: false}, this.showErrorAlert)
         return
       }
@@ -183,7 +189,6 @@ class FormSection extends React.Component {
     const { errorMessage, from, to, instructions, isFull, price, toDateMin, fromDateMax, paymentType, guestCount, email, phone, loading} = this.state
     const {selectedRoom, roomTypes} = this.props
     if (isFull) return <FullyBooked onClose={this.onCloseModal}/>
-
     if (instructions || loading) return <CheckEmail onClose={this.onCloseModal} instructions={instructions} loading={loading}/>
     return (
       <Fragment>

--- a/app/src/components/Booking/FormSection/index.jsx
+++ b/app/src/components/Booking/FormSection/index.jsx
@@ -35,8 +35,6 @@ class FormSection extends React.Component {
       email: '',
       phone: '+',
       instructions: null,
-      toDateMin: '2018-09-07',
-      fromDateMax: '2018-09-09',
       price: null,
       guestCount: '1',
       errorMessage: '',
@@ -181,7 +179,7 @@ class FormSection extends React.Component {
   }
 
   render () {
-    const { errorMessage, from, to, instructions, isFull, price, toDateMin, fromDateMax, paymentType, guestCount, email, phone, loading, totalDays} = this.state
+    const { errorMessage, from, to, instructions, isFull, price, paymentType, guestCount, email, phone, loading, totalDays} = this.state
     const {selectedRoom, roomTypes} = this.props
     if (isFull) return <FullyBooked onClose={this.onCloseModal}/>
     if (instructions || loading) return <CheckEmail onClose={this.onCloseModal} instructions={instructions} loading={loading}/>
@@ -198,8 +196,6 @@ class FormSection extends React.Component {
           to={to}
           roomTypes={roomTypes}
           selectedRoom={selectedRoom}
-          toDateMin={toDateMin}
-          fromDateMax={fromDateMax}
           price={price}
           email={email}
           phone={phone}

--- a/app/src/components/MyBookingSection/index.jsx
+++ b/app/src/components/MyBookingSection/index.jsx
@@ -78,6 +78,7 @@ export default class MyBookingSection extends React.Component {
     $('.alert').addClass('show')
     setTimeout(() => {
       $('.alert').removeClass('show')
+      this.setState({errorMessage: ''})
     }, 3000)
   }
 
@@ -85,12 +86,13 @@ export default class MyBookingSection extends React.Component {
     const {cancelTx, errorMessage} = this.state
     return (
       <Fragment>
-        <div className="alert fade fixed-top alert-danger text-center" role="alert">
+        {errorMessage && (<div className="alert fade fixed-top alert-danger text-center" role="alert">
           <span>{errorMessage}</span>
           <button type="button" className="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>
           </button>
-        </div>
+        </div>)
+      }
         <article className="py-3 py-md-5 border-bottom" id="my-booking">
           <div className="container">
             <div className="row justify-content-center">


### PR DESCRIPTION
- Manually removed the black screen if the modal returns an error. We should find a better way to do it, but with the current set up I didn't find it.
- Fixed error alert display 

this resolves #286 
this resolves #283