### PR TITLE
refactor(env): move .env to the root folder

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -2,13 +2,13 @@ const path = require('path');
 require('dotenv').config({
   path: path.resolve(
     process.cwd(),
+    '../',
     '.env',
   ),
 });
 
 const { startServer } = require('./app');
 const { SERVER_PORT } = require('./config');
-
 const server = startServer(SERVER_PORT);
 
 module.exports = {

--- a/server/test/models/Booking.spec.js
+++ b/server/test/models/Booking.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-require('dotenv').config({ path: './test/utils/.env' });
+require('dotenv').config({ path: '../../../.env.test' });
 const { expect } = require('chai');
 const { connectDB, disconnectDB } = require('../../src/models');
 const { Booking } = require('../../src/models/Booking');

--- a/server/test/routes/booking.spec.js
+++ b/server/test/routes/booking.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-require('dotenv').config({ path: './test/utils/.env' });
+require('dotenv').config({ path: '../../../.env.test' });
 const { expect } = require('chai');
 const mongoose = require('mongoose');
 const request = require('request-promise-native');

--- a/server/test/routes/email.spec.js
+++ b/server/test/routes/email.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-require('dotenv').config({ path: './test/utils/.env' });
+require('dotenv').config({ path: '../../../.env.test' });
 const { expect } = require('chai');
 const mongoose = require('mongoose');
 const request = require('request-promise-native');

--- a/server/test/routes/index.spec.js
+++ b/server/test/routes/index.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-require('dotenv').config({ path: './test/utils/.env' });
+require('dotenv').config({ path: '../../../.env.test' });
 const { expect } = require('chai');
 const request = require('request-promise-native');
 const { SERVER_PORT, BOOKING_POC_ADDRESS, WEB3_PROVIDER } = require('../../src/config');

--- a/server/test/services/booking.spec.js
+++ b/server/test/services/booking.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-require('dotenv').config({ path: './test/utils/.env' });
+require('dotenv').config({ path: '../../../.env.test' });
 const { expect } = require('chai');
 const sgMail = require('@sendgrid/mail');
 const sinon = require('sinon');

--- a/server/test/services/crypto.spec.js
+++ b/server/test/services/crypto.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-require('dotenv').config({ path: './test/utils/.env' });
+require('dotenv').config({ path: '../../../.env.test' });
 const { expect } = require('chai');
 const {
   generateKeyPair,

--- a/server/test/services/ethereum-listener.spec.js
+++ b/server/test/services/ethereum-listener.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 /* eslint-disable no-unused-expressions */
-require('dotenv').config({ path: './test/utils/.env' });
+require('dotenv').config({ path: '../../../.env.test' });
 const { expect } = require('chai');
 const { onBookingDone, onBookingCancel, _eventDispatcher } = require('../../src/services/ethereum-listener');
 const { events } = require('../utils/test-data');

--- a/server/test/services/mail.spec.js
+++ b/server/test/services/mail.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-require('dotenv').config({ path: './test/utils/.env' });
+require('dotenv').config({ path: '../../../.env.test' });
 const { expect } = require('chai');
 const sgMail = require('@sendgrid/mail');
 const sinon = require('sinon');

--- a/server/test/services/prices.spec.js
+++ b/server/test/services/prices.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 /* eslint-disable no-unused-expressions */
-require('dotenv').config({ path: './test/utils/.env' });
+require('dotenv').config({ path: '../../../.env.test' });
 const { expect } = require('chai');
 const { fetchETHPrice, fetchPrice, fetchLIFPrice } = require('../../src/services/prices');
 

--- a/server/test/services/web3.spec.js
+++ b/server/test/services/web3.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 /* eslint-disable no-unused-expressions */
-require('dotenv').config({ path: './test/utils/.env' });
+require('dotenv').config({ path: '../../../.env.test' });
 const { expect } = require('chai');
 const {
   getCancelBookingTx,


### PR DESCRIPTION
- moved `.env` to the root folder
- Now the env file for tests must be called `.env.test`

this resolves #354